### PR TITLE
Change URIs of users and accounts

### DIFF
--- a/accounts.md
+++ b/accounts.md
@@ -1,11 +1,11 @@
 # Money Accounts
 *This are NOT user accounts! Accounts are used as a money term.*
 ## Get all accounts from a user
-To get all accounts from a user, send a `GET` request with HTTP standard authentication to `/user/:username`.
+To get all accounts from a user, send a `GET` request with HTTP standard authentication to `/account`.
 
 `GET`
 ```
-/user/:username
+/account
 ```  
 ### Response
 ```json
@@ -29,14 +29,14 @@ To get all accounts from a user, send a `GET` request with HTTP standard authent
   ]
 }
 ```
-If no authentication is given, the server returns `401 Unauthorized`. If the authentication is wrong or the user is not the same as the given username, `403 Forbidden` is returned. If all goes well, `200 OK` is returned.
+If no authentication is given, the server returns `401 Unauthorized`. If the authentication is wrong, `403 Forbidden` is returned. If all goes well, `200 OK` is returned.
 
 ## Add a new account
-To add a new account, send a `POST` request with HTTP standard authentication to `/user/:username/:account`.
+To add a new account, send a `POST` request with HTTP standard authentication to `/account`.
 
 `POST`
 ```
-/user/:username/:account
+/account
 ```
 ### Response
-If no authentication is given, the server returns `401 Unauthorized`. If the authentication is wrong or the user is not the same as the given username, `403 Forbidden` is returned. If the account already exists, `400 Bad Request` is returned. If nothing goes wrong, the server returns `201 Created`.
+If no authentication is given, the server returns `401 Unauthorized`. If the authentication is wrong, `403 Forbidden` is returned. If the account already exists, `400 Bad Request` is returned. If nothing goes wrong, the server returns `201 Created`.

--- a/users.md
+++ b/users.md
@@ -1,22 +1,22 @@
 # Users
 ## Add a new user
-To add a new user, send a POST request to `/signup` with the username and the plaintext password in HTTP standard authentication. It is strongly recommended to use HTTPS for this, otherwise your password will be leaked.
+To add a new user, send a POST request to `/user` with the username and the plaintext password in HTTP standard authentication. It is strongly recommended to use HTTPS for this, otherwise your password will be leaked.
 
 `POST`
 ```
-/signup
+/user
 ```
 ### Response
 If the user does not exist, the server responds with `201 Created` and creates the user. If the user does exist, the server responds with `403 Forbidden`. In case that the request doesn't provide any authentication, the response is `401 Unauthorized`.
 
 ## Remove a user
-To remove a user, send a DELETE request to `/signup/:username` with HTTP standard authentication.
+To remove a user, send a DELETE request to `/user` with HTTP standard authentication.
 
 `DELETE`
 ```
-/signup/:username
+/user
 ```
 
 ### Response
-In case the user exists, the user is the same as the requesting user, and the authentication is correct, the user gets deleted and the server returns a `200 OK`.
-When no authentication is given, the server returns `401 Unauthorized`. When the requesting user and the given user aren't the same, the server returns `403 Forbidden`.
+In case the user exists and the authentication is correct, the user gets deleted and the server returns a `200 OK`.
+When no authentication is given, the server returns `401 Unauthorized`. When the authentication is incorrect, the return is `403 Forbidden`.

--- a/users.md
+++ b/users.md
@@ -1,6 +1,6 @@
 # Users
 ## Add a new user
-To add a new user, send a POST request to `/user` with the username and the plaintext password in HTTP standard authentication. It is strongly recommended to use HTTPS for this, otherwise your password will be leaked.
+To add a new user, send a `POST` request to `/user` with the username and the plaintext password in HTTP standard authentication. It is strongly recommended to use HTTPS for this, otherwise your password will be leaked.
 
 `POST`
 ```
@@ -10,7 +10,7 @@ To add a new user, send a POST request to `/user` with the username and the plai
 If the user does not exist, the server responds with `201 Created` and creates the user. If the user does exist, the server responds with `403 Forbidden`. In case that the request doesn't provide any authentication, the response is `401 Unauthorized`.
 
 ## Remove a user
-To remove a user, send a DELETE request to `/user` with HTTP standard authentication.
+To remove a user, send a `DELETE` request to `/user` with HTTP standard authentication.
 
 `DELETE`
 ```


### PR DESCRIPTION
This revision removes the /user prefix and replaces it with /account.
This is because the username is already specified over HTTP basic
authentification, and therefore the username in the URI is unnecessary,
and would provide an attack window for hackers that try to trick the
server into giving them other users info by specifying the wrong URI.
Also, this makes the API better understandable.